### PR TITLE
Add simple perceptron AI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # automakeaccgog
+
+This repository demonstrates a very simple AI implemented as a perceptron
+that learns the OR logic gate.
+
+## Running the example
+
+Run the unit tests to train the perceptron and verify its predictions:
+
+```bash
+python -m unittest
+```

--- a/perceptron.py
+++ b/perceptron.py
@@ -1,0 +1,22 @@
+class Perceptron:
+    """A simple single-layer perceptron for binary classification."""
+
+    def __init__(self, input_size, learning_rate=0.1):
+        self.learning_rate = learning_rate
+        # +1 for bias weight
+        self.weights = [0.0] * (input_size + 1)
+
+    def predict(self, inputs):
+        activation = self.weights[0]
+        for weight, value in zip(self.weights[1:], inputs):
+            activation += weight * value
+        return 1 if activation >= 0 else 0
+
+    def train(self, training_inputs, labels, epochs=10):
+        for _ in range(epochs):
+            for inputs, label in zip(training_inputs, labels):
+                prediction = self.predict(inputs)
+                update = self.learning_rate * (label - prediction)
+                self.weights[0] += update
+                for i in range(len(inputs)):
+                    self.weights[i + 1] += update * inputs[i]

--- a/test_perceptron.py
+++ b/test_perceptron.py
@@ -1,0 +1,16 @@
+import unittest
+from perceptron import Perceptron
+
+
+class TestPerceptron(unittest.TestCase):
+    def test_or_gate(self):
+        training_inputs = [(0, 0), (0, 1), (1, 0), (1, 1)]
+        labels = [0, 1, 1, 1]
+        p = Perceptron(input_size=2)
+        p.train(training_inputs, labels, epochs=10)
+        predictions = [p.predict(x) for x in training_inputs]
+        self.assertEqual(predictions, labels)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implement perceptron model to learn OR logic gate
- Add unit test verifying perceptron predictions
- Document usage in README

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_b_68aff68b3714832eb7449f4ae43f9ea0